### PR TITLE
feat: add command registry

### DIFF
--- a/cmd/dev-env/register.go
+++ b/cmd/dev-env/register.go
@@ -1,0 +1,17 @@
+package devenv
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/Gizzahub/gzh-cli/cmd/registry"
+)
+
+type devEnvCmdProvider struct{}
+
+func (devEnvCmdProvider) Command() *cobra.Command {
+	return NewDevEnvCmd()
+}
+
+func init() {
+	registry.Register(devEnvCmdProvider{})
+}

--- a/cmd/doctor/register.go
+++ b/cmd/doctor/register.go
@@ -1,0 +1,18 @@
+package doctor
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/Gizzahub/gzh-cli/cmd/registry"
+)
+
+type doctorCmdProvider struct{}
+
+func (doctorCmdProvider) Command() *cobra.Command {
+	DoctorCmd.Hidden = true
+	return DoctorCmd
+}
+
+func init() {
+	registry.Register(doctorCmdProvider{})
+}

--- a/cmd/git/register.go
+++ b/cmd/git/register.go
@@ -1,0 +1,17 @@
+package git
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/Gizzahub/gzh-cli/cmd/registry"
+)
+
+type gitCmdProvider struct{}
+
+func (gitCmdProvider) Command() *cobra.Command {
+	return NewGitCmd()
+}
+
+func init() {
+	registry.Register(gitCmdProvider{})
+}

--- a/cmd/ide/register.go
+++ b/cmd/ide/register.go
@@ -1,0 +1,19 @@
+package ide
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Gizzahub/gzh-cli/cmd/registry"
+)
+
+type ideCmdProvider struct{}
+
+func (ideCmdProvider) Command() *cobra.Command {
+	return NewIDECmd(context.Background())
+}
+
+func init() {
+	registry.Register(ideCmdProvider{})
+}

--- a/cmd/net-env/register.go
+++ b/cmd/net-env/register.go
@@ -1,0 +1,19 @@
+package netenv
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Gizzahub/gzh-cli/cmd/registry"
+)
+
+type netEnvCmdProvider struct{}
+
+func (netEnvCmdProvider) Command() *cobra.Command {
+	return NewNetEnvCmd(context.Background())
+}
+
+func init() {
+	registry.Register(netEnvCmdProvider{})
+}

--- a/cmd/pm/register.go
+++ b/cmd/pm/register.go
@@ -1,0 +1,19 @@
+package pm
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Gizzahub/gzh-cli/cmd/registry"
+)
+
+type pmCmdProvider struct{}
+
+func (pmCmdProvider) Command() *cobra.Command {
+	return NewPMCmd(context.Background())
+}
+
+func init() {
+	registry.Register(pmCmdProvider{})
+}

--- a/cmd/profile/register.go
+++ b/cmd/profile/register.go
@@ -1,0 +1,17 @@
+package profile
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/Gizzahub/gzh-cli/cmd/registry"
+)
+
+type profileCmdProvider struct{}
+
+func (profileCmdProvider) Command() *cobra.Command {
+	return NewProfileCmd()
+}
+
+func init() {
+	registry.Register(profileCmdProvider{})
+}

--- a/cmd/quality/register.go
+++ b/cmd/quality/register.go
@@ -1,0 +1,17 @@
+package quality
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/Gizzahub/gzh-cli/cmd/registry"
+)
+
+type qualityCmdProvider struct{}
+
+func (qualityCmdProvider) Command() *cobra.Command {
+	return NewQualityCmd()
+}
+
+func init() {
+	registry.Register(qualityCmdProvider{})
+}

--- a/cmd/registry/registry.go
+++ b/cmd/registry/registry.go
@@ -1,0 +1,31 @@
+package registry
+
+import (
+	"sync"
+
+	"github.com/spf13/cobra"
+)
+
+// CommandProvider defines an interface that exposes a Cobra command.
+type CommandProvider interface {
+	Command() *cobra.Command
+}
+
+var (
+	mu        sync.RWMutex
+	providers []CommandProvider
+)
+
+// Register adds a command provider to the registry.
+func Register(p CommandProvider) {
+	mu.Lock()
+	providers = append(providers, p)
+	mu.Unlock()
+}
+
+// List returns all registered command providers.
+func List() []CommandProvider {
+	mu.RLock()
+	defer mu.RUnlock()
+	return append([]CommandProvider(nil), providers...)
+}

--- a/cmd/repo-config/register.go
+++ b/cmd/repo-config/register.go
@@ -1,0 +1,17 @@
+package repoconfig
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/Gizzahub/gzh-cli/cmd/registry"
+)
+
+type repoConfigCmdProvider struct{}
+
+func (repoConfigCmdProvider) Command() *cobra.Command {
+	return NewRepoConfigCmd()
+}
+
+func init() {
+	registry.Register(repoConfigCmdProvider{})
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,17 +10,19 @@ import (
 
 	"github.com/spf13/cobra"
 
-	devenv "github.com/Gizzahub/gzh-cli/cmd/dev-env"
-	doctorcmd "github.com/Gizzahub/gzh-cli/cmd/doctor"
-	"github.com/Gizzahub/gzh-cli/cmd/git"
-	"github.com/Gizzahub/gzh-cli/cmd/ide"
-	netenv "github.com/Gizzahub/gzh-cli/cmd/net-env"
-	"github.com/Gizzahub/gzh-cli/cmd/pm"
-	"github.com/Gizzahub/gzh-cli/cmd/profile"
-	"github.com/Gizzahub/gzh-cli/cmd/quality"
-	repoconfig "github.com/Gizzahub/gzh-cli/cmd/repo-config"
+	_ "github.com/Gizzahub/gzh-cli/cmd/dev-env"
+	_ "github.com/Gizzahub/gzh-cli/cmd/doctor"
+	_ "github.com/Gizzahub/gzh-cli/cmd/git"
+	_ "github.com/Gizzahub/gzh-cli/cmd/ide"
+	_ "github.com/Gizzahub/gzh-cli/cmd/net-env"
+	_ "github.com/Gizzahub/gzh-cli/cmd/pm"
+	_ "github.com/Gizzahub/gzh-cli/cmd/profile"
+	_ "github.com/Gizzahub/gzh-cli/cmd/quality"
+	_ "github.com/Gizzahub/gzh-cli/cmd/repo-config"
+	_ "github.com/Gizzahub/gzh-cli/cmd/synclone"
+
+	"github.com/Gizzahub/gzh-cli/cmd/registry"
 	"github.com/Gizzahub/gzh-cli/cmd/shell"
-	synclone "github.com/Gizzahub/gzh-cli/cmd/synclone"
 	versioncmd "github.com/Gizzahub/gzh-cli/cmd/version"
 	"github.com/Gizzahub/gzh-cli/internal/logger"
 )
@@ -51,25 +53,14 @@ Utility Commands: doctor, version`,
 		},
 	}
 
-	// Core feature commands
-	cmd.AddCommand(pm.NewPMCmd(ctx))
-	cmd.AddCommand(synclone.NewSyncCloneCmd(ctx))
-	cmd.AddCommand(devenv.NewDevEnvCmd()) //nolint:contextcheck // Command setup doesn't require context propagation
-	cmd.AddCommand(ide.NewIDECmd(ctx))
-	cmd.AddCommand(netenv.NewNetEnvCmd(ctx))
-	cmd.AddCommand(repoconfig.NewRepoConfigCmd()) //nolint:contextcheck // Command setup doesn't require context propagation
-	cmd.AddCommand(profile.NewProfileCmd())       //nolint:contextcheck // Command setup doesn't require context propagation
-	cmd.AddCommand(git.NewGitCmd())               //nolint:contextcheck // Command setup doesn't require context propagation
-	cmd.AddCommand(quality.NewQualityCmd())       //nolint:contextcheck // Command setup doesn't require context propagation
+	for _, provider := range registry.List() {
+		cmd.AddCommand(provider.Command())
+	}
 
 	// Utility commands - set as hidden to reduce clutter in main help
 	versionCmd := versioncmd.NewVersionCmd(version)
 	versionCmd.Hidden = true
 	cmd.AddCommand(versionCmd)
-
-	doctorCmd := doctorcmd.DoctorCmd
-	doctorCmd.Hidden = true
-	cmd.AddCommand(doctorCmd)
 
 	// Shell command is hidden - only add if debug mode is enabled
 	if debugShell || os.Getenv("GZH_DEBUG_SHELL") == "1" {

--- a/cmd/synclone/register.go
+++ b/cmd/synclone/register.go
@@ -1,0 +1,19 @@
+package synclone
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Gizzahub/gzh-cli/cmd/registry"
+)
+
+type syncCloneCmdProvider struct{}
+
+func (syncCloneCmdProvider) Command() *cobra.Command {
+	return NewSyncCloneCmd(context.Background())
+}
+
+func init() {
+	registry.Register(syncCloneCmdProvider{})
+}

--- a/docs/20-architecture/20-system-overview.md
+++ b/docs/20-architecture/20-system-overview.md
@@ -313,7 +313,7 @@ Major refactoring effort that achieved significant improvements:
 
 1. Create command directory in `cmd/`
 1. Implement using BaseCommand pattern if applicable
-1. Register in `cmd/root.go`
+1. In `init()`, register the command with `registry.Register(newFeatureCmd{})`
 1. Add configuration section to unified schema
 1. Implement output formatting support
 


### PR DESCRIPTION
## Summary
- add command provider registry
- register existing commands via init hooks
- wire root command to registry and document registration process

## Testing
- `go test ./...` *(fails: TestNewAwsCmd, defaultIDEOptions undefined, repo-config integration build errors)*
- `go test ./cmd/dev-env -run TestNewAwsCmd -count=1` *(fails: expected "Manage AWS configuration files")*


------
https://chatgpt.com/codex/tasks/task_e_68adc1999d64832ab1798d66d8708f8d