### PR TITLE
feat: centralize config errors

### DIFF
--- a/cmd/dev-env/gcp_project.go
+++ b/cmd/dev-env/gcp_project.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	errors "github.com/Gizzahub/gzh-cli/internal/errors"
 	"github.com/manifoldco/promptui"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
@@ -72,7 +73,7 @@ func NewGCPProjectManager(ctx context.Context) (*GCPProjectManager, error) {
 	}
 
 	if err := manager.loadConfigurations(); err != nil {
-		return nil, fmt.Errorf("failed to load configurations: %w", err)
+		return nil, errors.Wrap(err, errors.ErrConfigNotFound)
 	}
 
 	if err := manager.loadProjects(); err != nil {

--- a/cmd/synclone/synclone.go
+++ b/cmd/synclone/synclone.go
@@ -5,12 +5,13 @@ package synclone
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/Gizzahub/gzh-cli/internal/config"
+	gerrors "github.com/Gizzahub/gzh-cli/internal/errors"
 	pkgconfig "github.com/Gizzahub/gzh-cli/pkg/config"
 	"github.com/Gizzahub/gzh-cli/pkg/github"
 	"github.com/Gizzahub/gzh-cli/pkg/gitlab"
@@ -129,7 +130,7 @@ func (o *syncCloneOptions) runWithCentralConfigService(ctx context.Context) erro
 			fmt.Println("Use --help or -h for more detailed usage information.")
 			return nil
 		}
-		return fmt.Errorf("failed to load configuration: %w", err)
+		return gerrors.Wrap(err, gerrors.ErrConfigNotFound)
 	}
 
 	// Show migration warnings if any
@@ -212,12 +213,5 @@ func (o *syncCloneOptions) executeProviderCloning(ctx context.Context, target pk
 
 // isConfigNotFoundError checks if the error indicates a configuration file was not found.
 func isConfigNotFoundError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	errMsg := strings.ToLower(err.Error())
-	return strings.Contains(errMsg, "no configuration file found") ||
-		strings.Contains(errMsg, "config file not found") ||
-		strings.Contains(errMsg, "configuration not found")
+	return errors.Is(err, gerrors.ErrConfigNotFound)
 }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+## Error handling
+
+Use the helpers in [`internal/errors`](../internal/errors) for consistent error
+management.
+
+```go
+import (
+    "errors"
+    "fmt"
+
+    gerrors "github.com/Gizzahub/gzh-cli/internal/errors"
+)
+
+func load() error {
+    if err := readConfig(); err != nil {
+        return gerrors.Wrap(err, gerrors.ErrConfigNotFound)
+    }
+    return nil
+}
+
+func handle(err error) {
+    if errors.Is(err, gerrors.ErrConfigNotFound) {
+        // configuration is missing
+    }
+
+    var serr *gerrors.StandardError
+    if errors.As(err, &serr) {
+        fmt.Println("code:", serr.Code)
+    }
+}
+```
+
+These patterns allow callers to detect specific failure scenarios and extract
+structured error information.

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/Gizzahub/gzh-cli/internal/env"
+	errors "github.com/Gizzahub/gzh-cli/internal/errors"
 	"github.com/Gizzahub/gzh-cli/pkg/config"
 )
 
@@ -168,7 +169,7 @@ func (s *DefaultConfigService) LoadConfiguration(_ context.Context, configPath s
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to load configuration: %w", err)
+		return nil, errors.Wrap(err, errors.ErrConfigNotFound)
 	}
 
 	s.config = s.unifiedFacade.GetConfiguration()
@@ -427,7 +428,7 @@ func (s *DefaultConfigService) findConfigFile() (string, error) {
 	// Try reading configuration to trigger file discovery
 	err := s.viper.ReadInConfig()
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, errors.ErrConfigNotFound)
 	}
 
 	return s.viper.ConfigFileUsed(), nil

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,27 @@
+package errors
+
+import (
+	sterrors "errors"
+	"fmt"
+)
+
+var (
+	// ErrConfigNotFound indicates that configuration could not be located.
+	ErrConfigNotFound = sterrors.New("config not found")
+	// ErrInvalidConfig indicates the provided configuration is invalid.
+	ErrInvalidConfig = sterrors.New("invalid config")
+	// ErrConfigNotLoaded indicates no configuration has been loaded.
+	ErrConfigNotLoaded = sterrors.New("no configuration loaded")
+)
+
+// Wrap annotates err with target to allow errors.Is/As checks on target while
+// preserving the original error as the cause.
+func Wrap(err, target error) error {
+	if err == nil {
+		return target
+	}
+	if target == nil {
+		return err
+	}
+	return fmt.Errorf("%w: %w", target, err)
+}

--- a/pkg/config/unified_facade.go
+++ b/pkg/config/unified_facade.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	errors "github.com/Gizzahub/gzh-cli/internal/errors"
 	"gopkg.in/yaml.v3"
 )
 
@@ -35,7 +36,7 @@ func (f *UnifiedConfigFacade) LoadConfiguration() error {
 func (f *UnifiedConfigFacade) LoadConfigurationFromPath(configPath string) error {
 	result, err := f.loader.LoadConfigFromPath(configPath)
 	if err != nil {
-		return fmt.Errorf("failed to load configuration: %w", err)
+		return errors.Wrap(err, errors.ErrConfigNotFound)
 	}
 
 	f.loadResult = result
@@ -66,7 +67,7 @@ func (f *UnifiedConfigFacade) GetBulkCloneIntegration() *BulkCloneIntegration {
 // SaveConfiguration saves the current configuration to a file.
 func (f *UnifiedConfigFacade) SaveConfiguration(configPath string) error {
 	if f.config == nil {
-		return fmt.Errorf("no configuration loaded")
+		return errors.ErrConfigNotLoaded
 	}
 
 	// Ensure directory exists
@@ -155,7 +156,7 @@ func (f *UnifiedConfigFacade) GetProviderConfig(provider string) *ProviderConfig
 // UpdateIDEConfig updates the IDE configuration.
 func (f *UnifiedConfigFacade) UpdateIDEConfig(ideConfig *IDEConfig) error {
 	if f.config == nil {
-		return fmt.Errorf("no configuration loaded")
+		return errors.ErrConfigNotLoaded
 	}
 
 	f.config.IDE = ideConfig
@@ -166,7 +167,7 @@ func (f *UnifiedConfigFacade) UpdateIDEConfig(ideConfig *IDEConfig) error {
 // UpdateDevEnvConfig updates the development environment configuration.
 func (f *UnifiedConfigFacade) UpdateDevEnvConfig(devEnvConfig *DevEnvConfig) error {
 	if f.config == nil {
-		return fmt.Errorf("no configuration loaded")
+		return errors.ErrConfigNotLoaded
 	}
 
 	f.config.DevEnv = devEnvConfig
@@ -177,7 +178,7 @@ func (f *UnifiedConfigFacade) UpdateDevEnvConfig(devEnvConfig *DevEnvConfig) err
 // UpdateNetEnvConfig updates the network environment configuration.
 func (f *UnifiedConfigFacade) UpdateNetEnvConfig(netEnvConfig *NetEnvConfig) error {
 	if f.config == nil {
-		return fmt.Errorf("no configuration loaded")
+		return errors.ErrConfigNotLoaded
 	}
 
 	f.config.NetEnv = netEnvConfig
@@ -188,7 +189,7 @@ func (f *UnifiedConfigFacade) UpdateNetEnvConfig(netEnvConfig *NetEnvConfig) err
 // UpdateSSHConfig updates the SSH configuration.
 func (f *UnifiedConfigFacade) UpdateSSHConfig(sshConfig *SSHConfigSettings) error {
 	if f.config == nil {
-		return fmt.Errorf("no configuration loaded")
+		return errors.ErrConfigNotLoaded
 	}
 
 	f.config.SSHConfig = sshConfig
@@ -199,7 +200,7 @@ func (f *UnifiedConfigFacade) UpdateSSHConfig(sshConfig *SSHConfigSettings) erro
 // ValidateUnifiedConfiguration validates the current configuration.
 func (f *UnifiedConfigFacade) ValidateUnifiedConfiguration() error {
 	if f.config == nil {
-		return fmt.Errorf("no configuration loaded")
+		return errors.ErrConfigNotLoaded
 	}
 
 	return f.loader.validateUnifiedConfig(f.config)
@@ -285,7 +286,7 @@ func (f *UnifiedConfigFacade) CreateDefaultConfiguration(configPath string) erro
 // ValidateConfiguration validates the current configuration.
 func (f *UnifiedConfigFacade) ValidateConfiguration() error {
 	if f.config == nil {
-		return fmt.Errorf("no configuration loaded")
+		return errors.ErrConfigNotLoaded
 	}
 
 	return f.loader.validateUnifiedConfig(f.config)
@@ -294,7 +295,7 @@ func (f *UnifiedConfigFacade) ValidateConfiguration() error {
 // GetProviderTargets returns all targets for a specific provider.
 func (f *UnifiedConfigFacade) GetProviderTargets(providerName string) ([]BulkCloneTarget, error) {
 	if f.integration == nil {
-		return nil, fmt.Errorf("no configuration loaded")
+		return nil, errors.ErrConfigNotLoaded
 	}
 
 	return f.integration.GetTargetsByProvider(providerName)
@@ -303,7 +304,7 @@ func (f *UnifiedConfigFacade) GetProviderTargets(providerName string) ([]BulkClo
 // GetAllTargets returns all configured targets.
 func (f *UnifiedConfigFacade) GetAllTargets() ([]BulkCloneTarget, error) {
 	if f.integration == nil {
-		return nil, fmt.Errorf("no configuration loaded")
+		return nil, errors.ErrConfigNotLoaded
 	}
 
 	return f.integration.GetAllTargets()
@@ -326,7 +327,7 @@ func (f *UnifiedConfigFacade) MigrateConfiguration(sourcePath, targetPath string
 // GenerateConfigurationReport generates a configuration report.
 func (f *UnifiedConfigFacade) GenerateConfigurationReport() (string, error) {
 	if f.config == nil {
-		return "", fmt.Errorf("no configuration loaded")
+		return "", errors.ErrConfigNotLoaded
 	}
 
 	targets, err := f.GetAllTargets()


### PR DESCRIPTION
## Summary
- add common config error variables and wrapper
- refactor config loading and CLI commands to use shared errors
- document `errors.Is`/`errors.As` usage in contributing guide

## Testing
- `go test ./...` *(fails: missing tooling and failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68adc24fbca0832aada550e987f7574c